### PR TITLE
Bugfix for list ValueError: array must not contain infs or NaNs

### DIFF
--- a/pychromvar/compute_deviations.py
+++ b/pychromvar/compute_deviations.py
@@ -5,6 +5,7 @@ import numpy as np
 from scipy import sparse
 from multiprocessing import Pool, cpu_count
 import logging
+from tqdm.auto import tqdm
 
 logging.basicConfig(
     format='%(asctime)s %(levelname)-8s %(message)s',
@@ -12,7 +13,7 @@ logging.basicConfig(
     datefmt='%Y-%m-%d %H:%M:%S')
 
 
-def compute_deviations(data: Union[AnnData, MuData], n_jobs=-1) -> AnnData:
+def compute_deviations(data: Union[AnnData, MuData], n_jobs=-1, chunk_size:int=10000) -> AnnData:
     """Compute raw and bias-corrected deviations.
 
     Parameters
@@ -27,7 +28,6 @@ def compute_deviations(data: Union[AnnData, MuData], n_jobs=-1) -> AnnData:
     Anndata
         An anndata object containing estimated deviations.
     """
-
     if isinstance(data, AnnData):
         adata = data
     elif isinstance(data, MuData) and "atac" in data.mod:
@@ -35,104 +35,68 @@ def compute_deviations(data: Union[AnnData, MuData], n_jobs=-1) -> AnnData:
     else:
         raise TypeError(
             "Expected AnnData or MuData object with 'atac' modality")
-
     # check if the object contains bias in Anndata.varm
     assert "bg_peaks" in adata.varm_keys(
     ), "Cannot find background peaks in the input object, please first run get_bg_peaks!"
-
-    if isinstance(adata.X, sparse.csr_matrix):
-        adata.X = np.array(adata.X.todense())
-
     logging.info('computing expectation reads per cell and peak...')
-    expectation = compute_expectation(count=adata.X)
-
-    logging.info('computing observed motif deviations...')
-    motif_match = adata.varm['motif_match'].transpose()
-
-    obs_dev = _compute_deviations(
-        (motif_match, adata.X.transpose(), expectation.transpose())).transpose()
-
+    expectation_obs, expectation_var = compute_expectation(count=adata.X)
+    logging.info('computing observed + bg motif deviations...')
+    motif_match = adata.varm['motif_match']
+    obs_dev = np.zeros((adata.n_obs, motif_match.shape[1]), dtype=np.float32)
     # compute background deviations for bias-correction
-    logging.info('computing background deviations...')
-
     n_bg_peaks = adata.varm['bg_peaks'].shape[1]
     bg_dev = np.zeros(shape=(n_bg_peaks, adata.n_obs, len(
         adata.uns['motif_name'])), dtype=np.float32)
-
-    if n_jobs == -1:
-        n_jobs = cpu_count()
-
-    if n_jobs == 1:
-        for i in range(n_bg_peaks):
+    ### instead of iterating over bg peaks, iterate over X
+    for item in tqdm(adata.chunked_X(chunk_size), position=0, leave=False, ncols=80, desc="rows"):
+        X, start, end = item
+        obs_dev[start:end, :] = _compute_deviations((motif_match, X, expectation_obs[start:end], expectation_var))
+        for i in tqdm(range(n_bg_peaks), position=1, leave=False, ncols=80, desc="bg"):
             bg_peak_idx = adata.varm['bg_peaks'][:, i]
-            bg_motif_match = adata.varm['motif_match'][bg_peak_idx, :].transpose(
-            )
-            bg_dev[i, :, :] = _compute_deviations((bg_motif_match, adata.X.transpose(),
-                                            expectation.transpose())).transpose()
-
-    elif n_jobs > 1:
-        # prepare arguments for multiprocessing
-        arguments_list = list()
-        for i in range(n_bg_peaks):
-            bg_peak_idx = adata.varm['bg_peaks'][:, i]
-            bg_motif_match = adata.varm['motif_match'][bg_peak_idx, :].transpose(
-            )
-            arguments = (bg_motif_match, adata.X.transpose(),
-                         expectation.transpose())
-            arguments_list.append(arguments)
-
-        # run the function with multiple cpus
-        with Pool(processes=n_jobs) as pool:
-            all_results = pool.map(_compute_deviations, arguments_list)
-
-        # parse the results
-        for i in range(n_bg_peaks):
-            bg_dev[i, :, :] = all_results[i].transpose()
-
+            bg_motif_match = adata.varm['motif_match'][bg_peak_idx, :]
+            bg_dev[i, start:end, :] = _compute_deviations((bg_motif_match, X, expectation_obs[start:end], expectation_var))
     mean_bg_dev = np.mean(bg_dev, axis=0)
     std_bg_dev = np.std(bg_dev, axis=0)
-
     dev = (obs_dev - mean_bg_dev) / std_bg_dev
     dev = np.nan_to_num(dev, 0)
-
     dev = AnnData(dev, dtype=np.float32)
     dev.obs_names = adata.obs_names
     dev.var_names = adata.uns['motif_name']
-
     return dev
 
 
 def _compute_deviations(arguments):
-    motif_match, count, expectation = arguments
+    motif_match, count, expectation_obs, expectation_var = arguments
+    ### motif_match: n_var x n_motif
+    ### count, exp: n_obs x n_var
+    observed = count.dot(motif_match)
+    expected = expectation_obs.dot(expectation_var.dot(motif_match))
+    if sparse.issparse(observed):
+        observed = observed.todense()
+    if sparse.issparse(expected):
+        expected = expected.todense()
+    out = np.zeros(expected.shape, dtype=expected.dtype)
+    np.divide(observed - expected, expected, out=out, where=expected != 0)
+    return out
 
-    observed = np.dot(motif_match, count)
-    expected = np.dot(motif_match, expectation)
 
-    return (observed - expected) / expected
-
-
-def compute_expectation(count: np.array) -> np.array:
+def compute_expectation(count: Union[np.array, sparse.csr_matrix]) -> np.array:
     """
-    Compute expetation accessibility per peak and per cell by assuming 
-    identical read probability per peak for each cell with a sequencing 
+    Compute expetation accessibility per peak and per cell by assuming
+    identical read probability per peak for each cell with a sequencing
     depth matched to that cell observed sequencing depth
 
     Parameters
     ----------
-    count : np.array
+    count : Union[np.array, sparse.csr_matrix]
         Count matrix containing raw accessibility data.
 
     Returns
     -------
-    np.array
-        Expectation matrix
+    np.array, np.array
+        Expectation matrix pair when multiplied gives
     """
-
-    a = np.sum(count, axis=0, keepdims=True)
-    a /= np.sum(count)
-
-    b = np.sum(count, axis=1, keepdims=True)
-
-    exp = np.dot(b, a)
-
-    return exp
+    a = np.asarray(count.sum(0), dtype=np.float32).reshape((1, count.shape[1]))
+    a /= a.sum()
+    b = np.asarray(count.sum(1), dtype=np.float32).reshape((count.shape[0], 1))
+    return b, a

--- a/pychromvar/preprocessing.py
+++ b/pychromvar/preprocessing.py
@@ -38,7 +38,7 @@ def get_bg_peaks(data: Union[AnnData, MuData], niterations=50, n_jobs=-1):
     # check if the object contains bias in Anndata.varm
     assert "gc_bias" in adata.var.columns, "Cannot find gc bias in the input object, please first run add_gc_bias!"
 
-    reads_per_peak = np.log10(np.sum(adata.X, axis=0))
+    reads_per_peak = np.log1p(adata.X.sum(axis=0)) / np.log(10)
 
     # here if reads_per_peak is a numpy matrix, convert it to array
     if isinstance(reads_per_peak, np.matrix):
@@ -59,7 +59,7 @@ def get_bg_peaks(data: Union[AnnData, MuData], niterations=50, n_jobs=-1):
 
 
 def add_peak_seq(data: Union[AnnData, MuData], genome_file: str, delimiter="-"):
-    """Add the DNA sequence of each peak to data object. 
+    """Add the DNA sequence of each peak to data object.
 
     Parameters
     ----------


### PR DESCRIPTION
Previously when there are zero reads in a peak, the sum(axis=0) = 0. Then log10(0) -> undefined. So using log1p should avoid this, and dividing by log(10) converts to base 10.

Additionally, using X.sum(0) instead of np.sum(X, axis=0) avoids densifying the matrix in this step.

Maybe in the future it would be good to similarly avoid densifying in compute_deviations.py as well?